### PR TITLE
fix(windows): use static docker container image in workflow

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -13,7 +13,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/${{ github.repository }}/usb-creator-mxe:latest
+    container: ghcr.io/unraid/usb-creator-next/usb-creator-mxe:latest
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Changed the ${{github repo}} to static unraid/usb-creator-tool so forks don't run into issues.